### PR TITLE
機能追加：studetn_course_statusの導入と付随する変更

### DIFF
--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -17,9 +17,11 @@ import org.springframework.web.bind.annotation.RestController;
 import raisetech.student.management.data.Course;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.data.StudentCourseStatus;
 import raisetech.student.management.domain.CourseForJson;
 import raisetech.student.management.domain.ResponseForDelete;
 import raisetech.student.management.domain.StudentCourseForJson;
+import raisetech.student.management.domain.StudentCourseWithStatus;
 import raisetech.student.management.domain.StudentDetail;
 import raisetech.student.management.domain.StudentDetailForJson;
 import raisetech.student.management.exception.ResourceConflictException;
@@ -146,6 +148,40 @@ public class StudentController {
     boolean deleted = service.searchStudentById(id).isDeleted();
     ResponseForDelete response = new ResponseForDelete(id, deleted);
     return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 受講生コース申し込み状況を「受講中」に更新
+   * @param studentCourseId
+   * @return 更新後の受講生コース情報（申し込み状況含む）
+   */
+  @Operation(summary = "受講生コース申し込み状況を「受講中」に更新", description = "指定されたIDの受講生コースの申し込み状況を「受講中」に更新します")
+  @PatchMapping("/updateStudentCourseStatusInProgress/{studentCourseId}")
+  public ResponseEntity<StudentCourseWithStatus> updateStudentCourseStatusInProgress(@PathVariable @Positive int studentCourseId)
+      throws ResourceNotFoundException, ResourceConflictException {
+    service.updateStudentCourseStatusInProgress(studentCourseId);
+
+    StudentCourse studentCourse = service.searchStudentCourseById(studentCourseId);
+    StudentCourseStatus studentCourseStatus = service.searchStudentCourseStatusByStudentCourseId(studentCourseId);
+    StudentCourseWithStatus studentCourseWithStatus = new StudentCourseWithStatus(studentCourse, studentCourseStatus);
+
+    return ResponseEntity.ok(studentCourseWithStatus);
+  }
+
+  /**
+   * 受講生コース申し込み状況を「受講完了」に更新
+   * @param studentCourseId
+   * @return 更新後の受講生コース情報（申し込み状況含む）
+   */
+  @Operation(summary = "受講生コース申し込み状況を「完了」に更新", description = "指定されたIDの受講生コースの申し込み状況を「完了」に更新します")
+  @PatchMapping("/updateStudentCourseStatusCompleted/{studentCourseId}")
+  public ResponseEntity<StudentCourseStatus> updateStudentCourseStatusCompleted(@PathVariable @Positive int studentCourseId)
+      throws ResourceNotFoundException, ResourceConflictException {
+    service.updateStudentCourseStatusCompleted(studentCourseId);
+
+    StudentCourseStatus studentCourseStatus = service.searchStudentCourseStatusByStudentCourseId(studentCourseId);
+
+    return ResponseEntity.ok(studentCourseStatus);
   }
 
 }

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -184,4 +184,24 @@ public class StudentController {
     return ResponseEntity.ok(studentCourseStatus);
   }
 
+  /**
+   * 受講中の受講生一覧検索
+   * @return 受講中の受講生詳細一覧
+   */
+  @GetMapping("/students/inProgress")
+  public List<StudentDetail> getStudentsInProgress() {
+    List<StudentDetail> studentDetails = service.searchStudentDetailsInProgress();
+    return studentDetails;
+  }
+
+  /**
+   * 仮申し込みの受講生一覧検索
+   * @return 仮申し込みの受講生詳細一覧
+   */
+  @GetMapping("/students/preEnrollment")
+  public List<StudentDetail> getStudentsPreEnrollment() {
+    List<StudentDetail> studentDetails = service.searchStudentDetailsPreEnrollment();
+    return studentDetails;
+  }
+
 }

--- a/src/main/java/raisetech/student/management/data/StudentCourse.java
+++ b/src/main/java/raisetech/student/management/data/StudentCourse.java
@@ -43,8 +43,9 @@ public class StudentCourse {
    * @return
    */
   public static StudentCourse initStudentCourse(int studentId, int courseId) {
-    LocalDate now = LocalDate.now();
-    return new StudentCourse(studentId, now, now.plusWeeks(16), courseId);
+    // 仮登録用に受講開始日を1週間後に設定
+    LocalDate startDate = LocalDate.now().plusWeeks(1);
+    return new StudentCourse(studentId, startDate, startDate.plusWeeks(16), courseId);
   }
 
   // テスト用にequalsとhashCodeをオーバーライド

--- a/src/main/java/raisetech/student/management/data/StudentCourseStatus.java
+++ b/src/main/java/raisetech/student/management/data/StudentCourseStatus.java
@@ -1,0 +1,40 @@
+package raisetech.student.management.data;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Schema(description = "受講生のコース情報の申し込み状況を保持するクラス")
+@Getter
+@Setter
+@AllArgsConstructor
+public class StudentCourseStatus {
+  private final int id;
+  private int studentCourseId;
+  private String status;
+
+  // @Insert用
+  public StudentCourseStatus(int studentCourseId) {
+    this.id = 0;
+    this.studentCourseId = studentCourseId;
+    this.status = "仮申し込み";
+  }
+
+  // テスト用にequalsとhashCodeをオーバーライド
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    StudentCourseStatus that = (StudentCourseStatus) o;
+    return id == that.id &&
+        studentCourseId == that.studentCourseId &&
+        Objects.equals(status, that.status);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, studentCourseId, status);
+  }
+}

--- a/src/main/java/raisetech/student/management/domain/StudentCourseWithStatus.java
+++ b/src/main/java/raisetech/student/management/domain/StudentCourseWithStatus.java
@@ -1,0 +1,27 @@
+package raisetech.student.management.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import lombok.Getter;
+import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.data.StudentCourseStatus;
+
+@Schema(description = "受講生のコース情報に申し込み状況を追加したクラス")
+@Getter
+public class StudentCourseWithStatus {
+  private final int id;
+  private int studentId;
+  private LocalDate startDate;
+  private LocalDate endDueDate;
+  private int courseId;
+  private String status; // 申し込み状況
+
+  public StudentCourseWithStatus(StudentCourse studentCourse, StudentCourseStatus studentCourseStatus) {
+    this.id = studentCourse.getId();
+    this.studentId = studentCourse.getStudentId();
+    this.startDate = studentCourse.getStartDate();
+    this.endDueDate = studentCourse.getEndDueDate();
+    this.courseId = studentCourse.getCourseId();
+    this.status = studentCourseStatus.getStatus();
+  }
+}

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -134,5 +134,19 @@ public interface StudentRepository {
    * @param studentCourse
    */
   void updateStudentCourse(StudentCourse studentCourse);
+
+  /**
+   * 仮申し込みの受講生コース申し込み状況を全件検索
+   * @return 仮申し込みの受講生コース申し込み状況一覧
+   */
+  List<StudentCourseStatus> searchStudentCourseStatusesPreEnrollment();
+
+  /**
+   * 受講中の受講生コース申し込み状況を全件検索
+   * @return 受講中の受講生コース申し込み状況一覧
+   */
+  List<StudentCourseStatus> searchStudentCourseStatusesInProgress();
+
+
 }
 

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.annotations.Mapper;
 import raisetech.student.management.data.Course;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.data.StudentCourseStatus;
 
 /**
  * 受講生情報を扱うリポジトリ
@@ -83,5 +84,55 @@ public interface StudentRepository {
    * @param id
    */
   void deleteStudent(int id);
+
+  /**
+   * 受講生のコース申し込み状況を全件検索
+   * @return 受講生のコース申し込み状況一覧
+   */
+  List<StudentCourseStatus> searchStudentCourseStatuses();
+
+  /**
+   * 受講生のコース申し込み状況をIDを指定して検索
+   * @param id
+   * @return 受講生のコース申し込み状況
+   */
+  Optional<StudentCourseStatus> searchStudentCourseStatusById(int id);
+
+  /**
+   * 受講生のコース申し込み状況を受講生コースIDを指定して検索
+   * @param studentCourseId
+   * @return 受講生のコース申し込み状況
+   */
+  Optional<StudentCourseStatus> searchStudentCourseStatusByStudentCourseId(int studentCourseId);
+
+  /**
+   * 受講生のコース申し込み状況を新規登録
+   * @param studentCourseStatus
+   */
+  void insertStudentCourseStatus(StudentCourseStatus studentCourseStatus);
+
+  /**
+   * 受講生のコース申し込み状況を受講中に更新
+   * @param studentCourseId
+   */
+  void updateStudentCourseStatusInProgress(int studentCourseId);
+
+  /**
+   * 受講生のコース申し込み状況を完了に更新
+   * @param studentCourseId
+   */
+  void updateStudentCourseStatusCompleted(int studentCourseId);
+
+  /**
+   * 受講生コース情報をIDを指定して検索
+   * @param id
+   */
+  Optional<StudentCourse> searchStudentCourseById(int id);
+
+  /**
+   * 受講生コース情報を更新
+   * @param studentCourse
+   */
+  void updateStudentCourse(StudentCourse studentCourse);
 }
 

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -224,4 +224,19 @@ public class StudentService {
     return repository.searchStudentCourseStatusByStudentCourseId(studentCourseId)
         .orElseThrow(() -> new ResourceNotFoundException("指定されたIDの受講生コース申し込み状況は存在しません"));
   }
+
+
+  public List<StudentDetail> searchStudentDetailsInProgress() {
+    List<Student> students = repository.searchStudents();
+    List<StudentCourse> studentCourses = repository.searchStudentCourses();
+    List<StudentCourseStatus> studentCourseStatusesInProgress = repository.searchStudentCourseStatusesInProgress();
+    return converter.convertStudentDetailsWithStatus(students, studentCourses, studentCourseStatusesInProgress);
+  }
+
+  public List<StudentDetail> searchStudentDetailsPreEnrollment() {
+    List<Student> students = repository.searchStudents();
+    List<StudentCourse> studentCourses = repository.searchStudentCourses();
+    List<StudentCourseStatus> studentCourseStatusesPreEnrollment = repository.searchStudentCourseStatusesPreEnrollment();
+    return converter.convertStudentDetailsWithStatus(students, studentCourses, studentCourseStatusesPreEnrollment);
+  }
 }

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -1,5 +1,6 @@
 package raisetech.student.management.service;
 
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -7,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import raisetech.student.management.data.Course;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.data.StudentCourseStatus;
 import raisetech.student.management.domain.StudentDetail;
 import raisetech.student.management.exception.ResourceConflictException;
 import raisetech.student.management.exception.ResourceNotFoundException;
@@ -147,8 +149,9 @@ public class StudentService {
     searchCourseNameById(studentCourse.getCourseId());
     // studentIdが存在するかを確認
     searchStudentById(studentCourse.getStudentId());
-    // 存在する場合は登録
+    // 存在する場合は登録（同時に申し込み状況を新規登録）
     repository.insertStudentCourse(studentCourse);
+    repository.insertStudentCourseStatus(new StudentCourseStatus(studentCourse.getId()));
   }
 
   @Transactional
@@ -165,5 +168,60 @@ public class StudentService {
     }
 
     repository.deleteStudent(id);
+  }
+
+  @Transactional(rollbackFor = ResourceNotFoundException.class)
+  public void updateStudentCourseStatusInProgress(int studentCourseId) throws ResourceNotFoundException, ResourceConflictException {
+    // 存在する受講生コースIDかを確認
+    StudentCourseStatus studentCourseStatus = repository.searchStudentCourseStatusByStudentCourseId(studentCourseId)
+        .orElseThrow(() -> new ResourceNotFoundException("指定されたIDの受講生コース申し込み状況は存在しません"));
+    // 現在の申し込み状況が仮申し込みでない場合はResourceConflictExceptionをスロー
+    if (studentCourseStatus.getStatus().equals("受講中")) {
+      throw new ResourceConflictException("既に受講中の受講生コースです");
+    } else if (studentCourseStatus.getStatus().equals("完了")) {
+      throw new ResourceConflictException("既に完了している受講生コースです");
+    } else if (!studentCourseStatus.getStatus().equals("仮申し込み")) {
+      throw new ResourceConflictException("申し込み状況が不正です");
+    }
+    // 問題なければ受講中に更新
+    repository.updateStudentCourseStatusInProgress(studentCourseId);
+    // startDateとendDueDateを設定
+    updateStudentCourseDateInProgress(studentCourseId);
+  }
+
+  private void updateStudentCourseDateInProgress(int studentCourseId) throws ResourceNotFoundException {
+    StudentCourse studentCourse = repository.searchStudentCourseById(studentCourseId)
+        .orElseThrow(() -> new ResourceNotFoundException("指定されたIDの受講生コース情報は存在しません"));
+    LocalDate now = LocalDate.now();
+    studentCourse.setStartDate(now);
+    studentCourse.setEndDueDate(now.plusWeeks(16));
+    repository.updateStudentCourse(studentCourse);
+  }
+
+  @Transactional
+  public void updateStudentCourseStatusCompleted(int studentCourseId) throws ResourceNotFoundException, ResourceConflictException {
+    // 存在する受講生コースIDかを確認
+    StudentCourseStatus studentCourseStatus = repository.searchStudentCourseStatusByStudentCourseId(studentCourseId)
+        .orElseThrow(() -> new ResourceNotFoundException("指定されたIDの受講生コース情報は存在しません"));
+    // 現在の申し込み状況が受講中でない場合はResourceConflictExceptionをスロー
+    if (studentCourseStatus.getStatus() == "完了") {
+      throw new ResourceConflictException("既に完了している受講生コースです");
+    } else if (studentCourseStatus.getStatus() == "仮申し込み") {
+      throw new ResourceConflictException("仮申し込みの受講生コースは完了できません");
+    } else if (!studentCourseStatus.getStatus().equals("受講中")) {
+      throw new ResourceConflictException("申し込み状況が不正です");
+    }
+    // 問題なければ完了に更新
+    repository.updateStudentCourseStatusCompleted(studentCourseId);
+  }
+
+  public StudentCourse searchStudentCourseById(int id) throws ResourceNotFoundException {
+    return repository.searchStudentCourseById(id)
+        .orElseThrow(() -> new ResourceNotFoundException("指定されたIDの受講生コース情報は存在しません"));
+  }
+
+  public StudentCourseStatus searchStudentCourseStatusByStudentCourseId(int studentCourseId) throws ResourceNotFoundException {
+    return repository.searchStudentCourseStatusByStudentCourseId(studentCourseId)
+        .orElseThrow(() -> new ResourceNotFoundException("指定されたIDの受講生コース申し込み状況は存在しません"));
   }
 }

--- a/src/main/java/raisetech/student/management/service/converter/StudentConverter.java
+++ b/src/main/java/raisetech/student/management/service/converter/StudentConverter.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.data.StudentCourseStatus;
 import raisetech.student.management.domain.StudentDetail;
 
 /**
@@ -28,6 +29,33 @@ public class StudentConverter {
           .collect(Collectors.toList());
       StudentDetail studentDetail = new StudentDetail(student, convertStudentCourses);
       studentDetails.add(studentDetail);
+    });
+    return studentDetails;
+  }
+
+  /**
+   * 申し込み状況に該当するものに限定して受講生情報に基づくコース情報をマッピングする
+   * @param students 受講生情報
+   * @param studentCourses 受講生のコース情報一覧
+   * @param studentCourseStatuses 受講生のコース申し込み状況一覧
+   * @return 受講生情報と受講生のコース情報を結合した情報
+   */
+  public List<StudentDetail> convertStudentDetailsWithStatus(List<Student> students, List<StudentCourse> studentCourses, List<StudentCourseStatus> studentCourseStatuses) {
+    List<StudentDetail> studentDetails = new ArrayList<>();
+    // studentCoursesからstudentCourseStatusesに含まれるもののみを抽出
+    List<StudentCourse> filteredStudentCourses = studentCourses.stream()
+        .filter(studentCourse -> studentCourseStatuses.stream()
+            .anyMatch(studentCourseStatus -> studentCourse.getId() == studentCourseStatus.getStudentCourseId()))
+        .collect(Collectors.toList());
+    // studentDetailに変換するが、studentCourseのないものは除外
+    students.forEach(student -> {
+      List<StudentCourse> convertStudentCourses = filteredStudentCourses.stream()
+          .filter(studentCourse -> student.getId() == studentCourse.getStudentId())
+          .collect(Collectors.toList());
+      if (!convertStudentCourses.isEmpty()) {
+        StudentDetail studentDetail = new StudentDetail(student, convertStudentCourses);
+        studentDetails.add(studentDetail);
+      }
     });
     return studentDetails;
   }

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -77,4 +77,12 @@
   <update id="updateStudentCourse" parameterType="raisetech.student.management.data.StudentCourse">
     UPDATE student_courses SET student_id = #{studentId}, start_date = #{startDate}, end_due_date = #{endDueDate}, course_id = #{courseId} WHERE id = #{id}
   </update>
+<!-- 仮申し込みの受講生コース申し込み状況を全件検索 -->
+  <select id="searchStudentCourseStatusesPreEnrollment" resultType="raisetech.student.management.data.StudentCourseStatus">
+    SELECT * FROM student_course_statuses WHERE status = '仮申し込み'
+  </select>
+<!-- 受講中の受講生コース申し込み状況を全件検索 -->
+  <select id="searchStudentCourseStatusesInProgress" resultType="raisetech.student.management.data.StudentCourseStatus">
+    SELECT * FROM student_course_statuses WHERE status = '受講中'
+  </select>
 </mapper>

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -45,4 +45,36 @@
   <update id="deleteStudent" parameterType="Integer">
     UPDATE students SET deleted = 1 WHERE id = #{id}
   </update>
+<!-- 受講生のコース申し込み状況を全件検索 -->
+  <select id="searchStudentCourseStatuses" resultType="raisetech.student.management.data.StudentCourseStatus">
+    SELECT * FROM student_course_statuses
+  </select>
+<!-- 受講生のコース申し込み状況をIDを指定して検索 -->
+  <select id="searchStudentCourseStatusById" resultType="raisetech.student.management.data.StudentCourseStatus">
+    SELECT * FROM student_course_statuses WHERE id = #{id}
+  </select>
+<!-- 受講生のコース申し込み状況を受講生IDを指定して検索 -->
+  <select id="searchStudentCourseStatusByStudentCourseId" resultType="raisetech.student.management.data.StudentCourseStatus">
+    SELECT * FROM student_course_statuses WHERE student_course_id = #{studentCourseId}
+  </select>
+<!-- 受講生のコース申し込み状況を新規登録　-->
+  <insert id="insertStudentCourseStatus" parameterType="raisetech.student.management.data.StudentCourseStatus" useGeneratedKeys="true" keyProperty="id">
+    INSERT INTO student_course_statuses VALUES (#{id}, #{studentCourseId}, #{status})
+  </insert>
+<!-- 受講生のコース申し込み状況を受講中に更新 -->
+  <update id="updateStudentCourseStatusInProgress" parameterType="Integer">
+    UPDATE student_course_statuses SET status = '受講中' WHERE student_course_id = #{studentCourseId}
+  </update>
+<!-- 受講生のコース申し込み状況を完了に更新 -->
+  <update id="updateStudentCourseStatusCompleted" parameterType="Integer">
+    UPDATE student_course_statuses SET status = '完了' WHERE student_course_id = #{studentCourseId}
+  </update>
+<!-- 受講生コース情報をIDを指定して検索 -->
+  <select id="searchStudentCourseById" resultType="raisetech.student.management.data.StudentCourse">
+    SELECT * FROM student_courses WHERE id = #{id}
+  </select>
+<!-- 受講生コース情報を更新 -->
+  <update id="updateStudentCourse" parameterType="raisetech.student.management.data.StudentCourse">
+    UPDATE student_courses SET student_id = #{studentId}, start_date = #{startDate}, end_due_date = #{endDueDate}, course_id = #{courseId} WHERE id = #{id}
+  </update>
 </mapper>

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -486,4 +486,18 @@ class StudentControllerTest {
         .andExpect(result -> assertTrue(
             result.getResolvedException() instanceof ConstraintViolationException));
   }
+
+  @Test
+  void 受講中の受講生一覧検索ができること() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/students/inProgress"))
+        .andExpect(status().isOk());
+    verify(service, times(1)).searchStudentDetailsInProgress();
+  }
+
+  @Test
+  void 仮申し込みの受講生一覧検索ができること() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/students/preEnrollment"))
+        .andExpect(status().isOk());
+    verify(service, times(1)).searchStudentDetailsPreEnrollment();
+  }
 }

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import raisetech.student.management.data.Course;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.data.StudentCourseStatus;
 import raisetech.student.management.domain.StudentDetail;
 import raisetech.student.management.exception.ResourceConflictException;
 import raisetech.student.management.exception.ResourceNotFoundException;
@@ -436,5 +437,53 @@ class StudentControllerTest {
     mockMvc.perform(MockMvcRequestBuilders.patch("/deleteStudent/" + id))
         .andExpect(status().isConflict())
         .andExpect(result -> assertTrue(result.getResolvedException() instanceof ResourceConflictException));
+  }
+
+  @Test
+  void 受講生コース申し込み状況を受講中に更新ができること() throws Exception {
+    int studentCourseId = 1;
+    when(service.searchStudentCourseById(studentCourseId))
+        .thenReturn(new StudentCourse(1, 1, null, null, 1));
+    when(service.searchStudentCourseStatusByStudentCourseId(studentCourseId))
+        .thenReturn(new StudentCourseStatus(1, 1, "完了"));
+    mockMvc.perform(MockMvcRequestBuilders.patch("/updateStudentCourseStatusInProgress/" + studentCourseId))
+        .andExpect(status().isOk());
+
+    verify(service, times(1)).updateStudentCourseStatusInProgress(studentCourseId);
+    verify(service, times(1)).searchStudentCourseById(studentCourseId);
+    verify(service, times(1)).searchStudentCourseStatusByStudentCourseId(studentCourseId);
+  }
+
+  @Test
+  void 受講生コース申し込み状況を受講中に更新_studentCourseIdが不正な場合の例外処理が適切であること() throws Exception {
+    int studentCourseId = 0;
+    mockMvc.perform(
+            MockMvcRequestBuilders.patch("/updateStudentCourseStatusInProgress/" + studentCourseId))
+        .andExpect(status().isBadRequest())
+        .andExpect(result -> assertTrue(
+            result.getResolvedException() instanceof ConstraintViolationException));
+
+  }
+
+  @Test
+  void 受講生コース申し込み状況を完了に更新ができること() throws Exception {
+    int studentCourseId = 1;
+    when(service.searchStudentCourseStatusByStudentCourseId(studentCourseId))
+        .thenReturn(new StudentCourseStatus(1, 1, "完了"));
+    mockMvc.perform(MockMvcRequestBuilders.patch("/updateStudentCourseStatusCompleted/" + studentCourseId))
+        .andExpect(status().isOk());
+
+    verify(service, times(1)).updateStudentCourseStatusCompleted(studentCourseId);
+    verify(service, times(1)).searchStudentCourseStatusByStudentCourseId(studentCourseId);
+  }
+
+  @Test
+  void 受講生コース申し込み状況を完了に更新_studentCourseIdが不正な場合の例外処理が適切であること() throws Exception {
+    int studentCourseId = 0;
+    mockMvc.perform(
+            MockMvcRequestBuilders.patch("/updateStudentCourseStatusCompleted/" + studentCourseId))
+        .andExpect(status().isBadRequest())
+        .andExpect(result -> assertTrue(
+            result.getResolvedException() instanceof ConstraintViolationException));
   }
 }

--- a/src/test/java/raisetech/student/management/repository/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/student/management/repository/StudentRepositoryTest.java
@@ -236,4 +236,25 @@ class StudentRepositoryTest {
         .ignoringFields("startDate", "endDueDate")
         .isEqualTo(original);
   }
+
+  @Test
+  void 仮申し込みの受講生コース情報の申し込み状況を全件検索ができること_情報が適切であること() {
+    List<StudentCourseStatus> actual = sut.searchStudentCourseStatusesPreEnrollment();
+    List<StudentCourseStatus> expected = List.of(
+        new StudentCourseStatus(5, 5, "仮申し込み")
+    );
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  @Test
+  void 受講中の受講生コース情報の申し込み状況を全件検索ができること_情報が適切であること() {
+    List<StudentCourseStatus> actual = sut.searchStudentCourseStatusesInProgress();
+    List<StudentCourseStatus> expected = List.of(
+        new StudentCourseStatus(1, 1, "受講中"),
+        new StudentCourseStatus(2, 2, "受講中"),
+        new StudentCourseStatus(3, 3, "受講中"),
+        new StudentCourseStatus(4, 4, "受講中")
+    );
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+  }
 }

--- a/src/test/java/raisetech/student/management/repository/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/student/management/repository/StudentRepositoryTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import raisetech.student.management.data.Course;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.data.StudentCourseStatus;
 import raisetech.student.management.domain.CourseForJson;
 import raisetech.student.management.domain.StudentDetailForJson;
 
@@ -151,5 +152,88 @@ class StudentRepositoryTest {
     Optional<Student> actualOptional = sut.searchStudentById(1);
     Student actual = actualOptional.get();
     assertThat(actual.isDeleted()).isTrue();
+  }
+
+  @Test
+  void 受講生コース情報の申し込み状況の全件検索ができること_情報が適切であること() {
+    List<StudentCourseStatus> actual = sut.searchStudentCourseStatuses();
+    List<StudentCourseStatus> expected = List.of(
+        new StudentCourseStatus(1, 1, "受講中"),
+        new StudentCourseStatus(2, 2, "受講中"),
+        new StudentCourseStatus(3, 3, "受講中"),
+        new StudentCourseStatus(4, 4, "受講中"),
+        new StudentCourseStatus(5, 5, "仮申し込み"),
+        new StudentCourseStatus(6, 6, "完了")
+    );
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  @Test
+  void 受講生コース情報の申し込み状況のIDを指定して検索ができること_指定したIDの情報が取得できること() {
+    Optional<StudentCourseStatus> actual = sut.searchStudentCourseStatusById(1);
+    StudentCourseStatus expected = new StudentCourseStatus(1, 1, "受講中");
+    assertThat(actual).isEqualTo(Optional.of(expected));
+  }
+
+  @Test
+  void 受講生コース情報の申し込み状況を受講生コースIDを指定して検索ができること_指定したIDの情報が取得できること() {
+    Optional<StudentCourseStatus> actual = sut.searchStudentCourseStatusByStudentCourseId(1);
+    StudentCourseStatus expected = new StudentCourseStatus(1, 1, "受講中");
+    assertThat(actual).isEqualTo(Optional.of(expected));
+  }
+
+  @Test
+  void 受講生コース情報の申し込み状況が新規登録できること_登録前後で件数が1件増えていること() {
+    StudentCourseStatus studentCourseStatus = new StudentCourseStatus(100);
+    int countPresentStudentCourseStatuses = sut.searchStudentCourseStatuses().size();
+    sut.insertStudentCourseStatus(studentCourseStatus);
+    List<StudentCourseStatus> actual = sut.searchStudentCourseStatuses();
+    assertThat(actual.size()).isEqualTo(countPresentStudentCourseStatuses + 1);
+  }
+
+  @Test
+  void 受講生コース情報の申し込み状況を受講中に更新できること_更新前後で状況が変わっていること() {
+    sut.updateStudentCourseStatusInProgress(5);
+    Optional<StudentCourseStatus> actualOptional = sut.searchStudentCourseStatusById(5);
+    StudentCourseStatus actual = actualOptional.get();
+    assertThat(actual.getStatus()).isEqualTo("受講中");
+  }
+
+  @Test
+  void 受講生コース情報の申し込み状況を完了に更新できること_更新前後で状況が変わっていること() {
+    sut.updateStudentCourseStatusCompleted(4);
+    Optional<StudentCourseStatus> actualOptional = sut.searchStudentCourseStatusById(4);
+    StudentCourseStatus actual = actualOptional.get();
+    assertThat(actual.getStatus()).isEqualTo("完了");
+  }
+
+  @Test
+  void 受講生コース情報をIDを指定して検索ができること_指定したIDの情報が取得できること() {
+    Optional<StudentCourse> actual = sut.searchStudentCourseById(1);
+    StudentCourse expected = new StudentCourse(1, 1, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 4, 25), 1);
+    assertThat(actual).isEqualTo(Optional.of(expected));
+  }
+
+  @Test
+  void 受講生コース情報の更新ができること_更新前後で情報が変わっていること() {
+    Optional<StudentCourse> studentCourseOptional = sut.searchStudentCourseById(1);
+    StudentCourse studentCourse = studentCourseOptional.get();
+    // 元の情報を保存
+    StudentCourse original = studentCourse;
+    // startDateとendDueDateを変更
+    studentCourse.setStartDate(LocalDate.of(2024, 1, 2));
+    studentCourse.setEndDueDate(LocalDate.of(2024, 4, 26));
+    // 更新
+    sut.updateStudentCourse(studentCourse);
+    Optional<StudentCourse> actualOptional = sut.searchStudentCourseById(1);
+    StudentCourse actual = actualOptional.get();
+    // startDateとendDueDateが変更されていることを確認
+    assertThat(actual.getStartDate()).isEqualTo(LocalDate.of(2024, 1, 2));
+    assertThat(actual.getEndDueDate()).isEqualTo(LocalDate.of(2024, 4, 26));
+    // 他の情報は変更されていないことを確認
+    assertThat(actual)
+        .usingRecursiveComparison()
+        .ignoringFields("startDate", "endDueDate")
+        .isEqualTo(original);
   }
 }

--- a/src/test/java/raisetech/student/management/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/student/management/service/StudentServiceTest.java
@@ -398,4 +398,40 @@ class StudentServiceTest {
     assertThrows(ResourceNotFoundException.class, () -> sut.searchStudentCourseStatusByStudentCourseId(studentCourseId));
   }
 
+  @Test
+  void 受講中のコースを含む受講生詳細の全件検索_リポジトリの処理が適切に呼び出せること() {
+    // 事前準備
+    List<Student> students = new ArrayList<>();
+    List<StudentCourse> studentCourses = new ArrayList<>();
+    List<StudentCourseStatus> studentCourseStatuses = new ArrayList<>();
+    Mockito.when(repository.searchStudents()).thenReturn(students);
+    Mockito.when(repository.searchStudentCourses()).thenReturn(studentCourses);
+    Mockito.when(repository.searchStudentCourseStatusesInProgress()).thenReturn(studentCourseStatuses);
+    // 実行
+    List<StudentDetail> actual = sut.searchStudentDetailsInProgress();
+    // 検証
+    Mockito.verify(repository, Mockito.times(1)).searchStudents();
+    Mockito.verify(repository, Mockito.times(1)).searchStudentCourses();
+    Mockito.verify(repository, Mockito.times(1)).searchStudentCourseStatusesInProgress();
+    Mockito.verify(converter, Mockito.times(1)).convertStudentDetailsWithStatus(students, studentCourses, studentCourseStatuses);
+  }
+
+  @Test
+  void 仮申し込みのコースを含む受講生詳細の全件検索_リポジトリの処理が適切に呼び出せること() {
+    // 事前準備
+    List<Student> students = new ArrayList<>();
+    List<StudentCourse> studentCourses = new ArrayList<>();
+    List<StudentCourseStatus> studentCourseStatuses = new ArrayList<>();
+    Mockito.when(repository.searchStudents()).thenReturn(students);
+    Mockito.when(repository.searchStudentCourses()).thenReturn(studentCourses);
+    Mockito.when(repository.searchStudentCourseStatusesPreEnrollment()).thenReturn(studentCourseStatuses);
+    // 実行
+    List<StudentDetail> actual = sut.searchStudentDetailsPreEnrollment();
+    // 検証
+    Mockito.verify(repository, Mockito.times(1)).searchStudents();
+    Mockito.verify(repository, Mockito.times(1)).searchStudentCourses();
+    Mockito.verify(repository, Mockito.times(1)).searchStudentCourseStatusesPreEnrollment();
+    Mockito.verify(converter, Mockito.times(1)).convertStudentDetailsWithStatus(students, studentCourses, studentCourseStatuses);
+  }
+
 }

--- a/src/test/java/raisetech/student/management/service/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/student/management/service/converter/StudentConverterTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.data.StudentCourseStatus;
 import raisetech.student.management.domain.StudentDetail;
 
 class StudentConverterTest {
@@ -104,5 +105,53 @@ class StudentConverterTest {
         .anyMatch(studentCourse -> studentCourse.getId() == 3)).isFalse();
   }
 
+  @Test
+  void 申し込み状況に該当するものに限定して受講生詳細の変換でStudentCourseStatusに含まれるStudentCourseのみマッピングされること() {
+    // 事前準備
+    List<Student> students = new ArrayList<>(List.of(
+        new Student(1, "AAA", "aaa", null, "aaa@example.com", null, 1, null, null, false),
+        new Student(2, "BBB", "bbb", null, "bbb@example.com", null, 2, null, null, false)
+    ));
+    List<StudentCourse> studentCourses = new ArrayList<>(List.of(
+        new StudentCourse(1, 1, null, null, 1),
+        new StudentCourse(2, 1, null, null, 2),
+        new StudentCourse(3, 2, null, null, 1)
+    ));
+    List<StudentCourseStatus> studentCourseStatuses = new ArrayList<>(List.of(
+        new StudentCourseStatus(2, 2, "受講中")
+    ));
+    // 実行
+    List<StudentDetail> actual = sut.convertStudentDetailsWithStatus(students, studentCourses,
+        studentCourseStatuses);
+    // 検証
+    // actualのサイズが1であること
+    assertThat(actual.size()).isEqualTo(1);
+    // actualのStudentIdが1であること
+    assertThat(actual.get(0).getStudent().getId()).isEqualTo(1);
+    // actualのStudentCourseのサイズが1であること
+    assertThat(actual.get(0).getStudentCourses().size()).isEqualTo(1);
+    // actualのStudentCourseのIdが2であること
+    assertThat(actual.get(0).getStudentCourses().get(0).getId()).isEqualTo(2);
+  }
 
+  @Test
+  void 申し込み状況に該当するものに限定して受講生詳細の変換でStudentCourseStatusが空である場合はからのListが返されること() {
+    // 事前準備
+    List<Student> students = new ArrayList<>(List.of(
+        new Student(1, "AAA", "aaa", null, "aaa@example.com", null, 1, null, null, false),
+        new Student(2, "BBB", "bbb", null, "bbb@example.com", null, 2, null, null, false)
+    ));
+    List<StudentCourse> studentCourses = new ArrayList<>(List.of(
+        new StudentCourse(1, 1, null, null, 1),
+        new StudentCourse(2, 1, null, null, 2),
+        new StudentCourse(3, 2, null, null, 1)
+    ));
+    List<StudentCourseStatus> studentCourseStatuses = new ArrayList<>();
+    // 実行
+    List<StudentDetail> actual = sut.convertStudentDetailsWithStatus(students, studentCourses,
+        studentCourseStatuses);
+    // 検証
+    // actualが空であること
+    assertThat(actual.size()).isEqualTo(0);
+  }
 }

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -21,3 +21,12 @@ INSERT INTO student_courses (student_id, start_date, end_due_date, course_id) VA
 (3, '2024-01-01', '2024-04-25', 1),
 (4, '2024-01-01', '2024-04-25', 2),
 (5, '2024-01-01', '2024-04-25', 4);
+
+-- Insert data into the student_course_statuses table
+INSERT INTO student_course_statuses (student_course_id, status) VALUES
+(1, '受講中'),
+(2, '受講中'),
+(3, '受講中'),
+(4, '受講中'),
+(5, '仮申し込み'),
+(6, '完了');

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -24,3 +24,9 @@ CREATE TABLE courses (
     name VARCHAR(20) NOT NULL,
     price INT
 );
+
+CREATE TABLE student_course_statuses (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    student_course_id INT NOT NULL UNIQUE,
+    status VARCHAR(10) NOT NULL
+);


### PR DESCRIPTION
カリキュラム44の課題の1段目として以下を実施しています。
2段目の課題（検索機能の追加）は別途PRを作成します。

## 概要
受講コース状況申し込み状況テーブル（student_course_statuses）を作成し、状況の遷移（仮申し込み→受講中→完了）を管理できるように機能追加

## コード変更内容
### Repository
- student_course_statusesに関わる各種@Insert、@Selectメソッド追加
- student_coursesのメソッド追加（基本的な@Selectメソッドが不足していたため）

### Service
- 新規受講生登録時に申し込み状況の登録を追加
- 申し込み状況を更新するメソッド2つを追加
- Repositoryで追加したid検索メソッドを使用するためのメソッド追加

### Controller
- 申し込み状況を更新するAPI2つを追加

### その他
- 上記に関わるテストコードの追加
- StudentCourseの初期化メソッドで、受講期間を変更（初期化時点では仮申し込みのため）