### PR TITLE
機能追加：student_course_statusを用いた検索機能

### DIFF
--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -184,4 +184,24 @@ public class StudentController {
     return ResponseEntity.ok(studentCourseStatus);
   }
 
+  /**
+   * 受講中の受講生一覧検索
+   * @return 受講中の受講生詳細一覧
+   */
+  @GetMapping("/students/inProgress")
+  public List<StudentDetail> getStudentsInProgress() {
+    List<StudentDetail> studentDetails = service.searchStudentDetailsInProgress();
+    return studentDetails;
+  }
+
+  /**
+   * 仮申し込みの受講生一覧検索
+   * @return 仮申し込みの受講生詳細一覧
+   */
+  @GetMapping("/students/preEnrollment")
+  public List<StudentDetail> getStudentsPreEnrollment() {
+    List<StudentDetail> studentDetails = service.searchStudentDetailsPreEnrollment();
+    return studentDetails;
+  }
+
 }

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -134,5 +134,19 @@ public interface StudentRepository {
    * @param studentCourse
    */
   void updateStudentCourse(StudentCourse studentCourse);
+
+  /**
+   * 仮申し込みの受講生コース申し込み状況を全件検索
+   * @return 仮申し込みの受講生コース申し込み状況一覧
+   */
+  List<StudentCourseStatus> searchStudentCourseStatusesPreEnrollment();
+
+  /**
+   * 受講中の受講生コース申し込み状況を全件検索
+   * @return 受講中の受講生コース申し込み状況一覧
+   */
+  List<StudentCourseStatus> searchStudentCourseStatusesInProgress();
+
+
 }
 

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -224,4 +224,19 @@ public class StudentService {
     return repository.searchStudentCourseStatusByStudentCourseId(studentCourseId)
         .orElseThrow(() -> new ResourceNotFoundException("指定されたIDの受講生コース申し込み状況は存在しません"));
   }
+
+
+  public List<StudentDetail> searchStudentDetailsInProgress() {
+    List<Student> students = repository.searchStudents();
+    List<StudentCourse> studentCourses = repository.searchStudentCourses();
+    List<StudentCourseStatus> studentCourseStatusesInProgress = repository.searchStudentCourseStatusesInProgress();
+    return converter.convertStudentDetailsWithStatus(students, studentCourses, studentCourseStatusesInProgress);
+  }
+
+  public List<StudentDetail> searchStudentDetailsPreEnrollment() {
+    List<Student> students = repository.searchStudents();
+    List<StudentCourse> studentCourses = repository.searchStudentCourses();
+    List<StudentCourseStatus> studentCourseStatusesPreEnrollment = repository.searchStudentCourseStatusesPreEnrollment();
+    return converter.convertStudentDetailsWithStatus(students, studentCourses, studentCourseStatusesPreEnrollment);
+  }
 }

--- a/src/main/java/raisetech/student/management/service/converter/StudentConverter.java
+++ b/src/main/java/raisetech/student/management/service/converter/StudentConverter.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.data.StudentCourseStatus;
 import raisetech.student.management.domain.StudentDetail;
 
 /**
@@ -28,6 +29,33 @@ public class StudentConverter {
           .collect(Collectors.toList());
       StudentDetail studentDetail = new StudentDetail(student, convertStudentCourses);
       studentDetails.add(studentDetail);
+    });
+    return studentDetails;
+  }
+
+  /**
+   * 申し込み状況に該当するものに限定して受講生情報に基づくコース情報をマッピングする
+   * @param students 受講生情報
+   * @param studentCourses 受講生のコース情報一覧
+   * @param studentCourseStatuses 受講生のコース申し込み状況一覧
+   * @return 受講生情報と受講生のコース情報を結合した情報
+   */
+  public List<StudentDetail> convertStudentDetailsWithStatus(List<Student> students, List<StudentCourse> studentCourses, List<StudentCourseStatus> studentCourseStatuses) {
+    List<StudentDetail> studentDetails = new ArrayList<>();
+    // studentCoursesからstudentCourseStatusesに含まれるもののみを抽出
+    List<StudentCourse> filteredStudentCourses = studentCourses.stream()
+        .filter(studentCourse -> studentCourseStatuses.stream()
+            .anyMatch(studentCourseStatus -> studentCourse.getId() == studentCourseStatus.getStudentCourseId()))
+        .collect(Collectors.toList());
+    // studentDetailに変換するが、studentCourseのないものは除外
+    students.forEach(student -> {
+      List<StudentCourse> convertStudentCourses = filteredStudentCourses.stream()
+          .filter(studentCourse -> student.getId() == studentCourse.getStudentId())
+          .collect(Collectors.toList());
+      if (!convertStudentCourses.isEmpty()) {
+        StudentDetail studentDetail = new StudentDetail(student, convertStudentCourses);
+        studentDetails.add(studentDetail);
+      }
     });
     return studentDetails;
   }

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -77,4 +77,12 @@
   <update id="updateStudentCourse" parameterType="raisetech.student.management.data.StudentCourse">
     UPDATE student_courses SET student_id = #{studentId}, start_date = #{startDate}, end_due_date = #{endDueDate}, course_id = #{courseId} WHERE id = #{id}
   </update>
+<!-- 仮申し込みの受講生コース申し込み状況を全件検索 -->
+  <select id="searchStudentCourseStatusesPreEnrollment" resultType="raisetech.student.management.data.StudentCourseStatus">
+    SELECT * FROM student_course_statuses WHERE status = '仮申し込み'
+  </select>
+<!-- 受講中の受講生コース申し込み状況を全件検索 -->
+  <select id="searchStudentCourseStatusesInProgress" resultType="raisetech.student.management.data.StudentCourseStatus">
+    SELECT * FROM student_course_statuses WHERE status = '受講中'
+  </select>
 </mapper>

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -486,4 +486,18 @@ class StudentControllerTest {
         .andExpect(result -> assertTrue(
             result.getResolvedException() instanceof ConstraintViolationException));
   }
+
+  @Test
+  void 受講中の受講生一覧検索ができること() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/students/inProgress"))
+        .andExpect(status().isOk());
+    verify(service, times(1)).searchStudentDetailsInProgress();
+  }
+
+  @Test
+  void 仮申し込みの受講生一覧検索ができること() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/students/preEnrollment"))
+        .andExpect(status().isOk());
+    verify(service, times(1)).searchStudentDetailsPreEnrollment();
+  }
 }

--- a/src/test/java/raisetech/student/management/repository/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/student/management/repository/StudentRepositoryTest.java
@@ -236,4 +236,25 @@ class StudentRepositoryTest {
         .ignoringFields("startDate", "endDueDate")
         .isEqualTo(original);
   }
+
+  @Test
+  void 仮申し込みの受講生コース情報の申し込み状況を全件検索ができること_情報が適切であること() {
+    List<StudentCourseStatus> actual = sut.searchStudentCourseStatusesPreEnrollment();
+    List<StudentCourseStatus> expected = List.of(
+        new StudentCourseStatus(5, 5, "仮申し込み")
+    );
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  @Test
+  void 受講中の受講生コース情報の申し込み状況を全件検索ができること_情報が適切であること() {
+    List<StudentCourseStatus> actual = sut.searchStudentCourseStatusesInProgress();
+    List<StudentCourseStatus> expected = List.of(
+        new StudentCourseStatus(1, 1, "受講中"),
+        new StudentCourseStatus(2, 2, "受講中"),
+        new StudentCourseStatus(3, 3, "受講中"),
+        new StudentCourseStatus(4, 4, "受講中")
+    );
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+  }
 }

--- a/src/test/java/raisetech/student/management/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/student/management/service/StudentServiceTest.java
@@ -398,4 +398,40 @@ class StudentServiceTest {
     assertThrows(ResourceNotFoundException.class, () -> sut.searchStudentCourseStatusByStudentCourseId(studentCourseId));
   }
 
+  @Test
+  void 受講中のコースを含む受講生詳細の全件検索_リポジトリの処理が適切に呼び出せること() {
+    // 事前準備
+    List<Student> students = new ArrayList<>();
+    List<StudentCourse> studentCourses = new ArrayList<>();
+    List<StudentCourseStatus> studentCourseStatuses = new ArrayList<>();
+    Mockito.when(repository.searchStudents()).thenReturn(students);
+    Mockito.when(repository.searchStudentCourses()).thenReturn(studentCourses);
+    Mockito.when(repository.searchStudentCourseStatusesInProgress()).thenReturn(studentCourseStatuses);
+    // 実行
+    List<StudentDetail> actual = sut.searchStudentDetailsInProgress();
+    // 検証
+    Mockito.verify(repository, Mockito.times(1)).searchStudents();
+    Mockito.verify(repository, Mockito.times(1)).searchStudentCourses();
+    Mockito.verify(repository, Mockito.times(1)).searchStudentCourseStatusesInProgress();
+    Mockito.verify(converter, Mockito.times(1)).convertStudentDetailsWithStatus(students, studentCourses, studentCourseStatuses);
+  }
+
+  @Test
+  void 仮申し込みのコースを含む受講生詳細の全件検索_リポジトリの処理が適切に呼び出せること() {
+    // 事前準備
+    List<Student> students = new ArrayList<>();
+    List<StudentCourse> studentCourses = new ArrayList<>();
+    List<StudentCourseStatus> studentCourseStatuses = new ArrayList<>();
+    Mockito.when(repository.searchStudents()).thenReturn(students);
+    Mockito.when(repository.searchStudentCourses()).thenReturn(studentCourses);
+    Mockito.when(repository.searchStudentCourseStatusesPreEnrollment()).thenReturn(studentCourseStatuses);
+    // 実行
+    List<StudentDetail> actual = sut.searchStudentDetailsPreEnrollment();
+    // 検証
+    Mockito.verify(repository, Mockito.times(1)).searchStudents();
+    Mockito.verify(repository, Mockito.times(1)).searchStudentCourses();
+    Mockito.verify(repository, Mockito.times(1)).searchStudentCourseStatusesPreEnrollment();
+    Mockito.verify(converter, Mockito.times(1)).convertStudentDetailsWithStatus(students, studentCourses, studentCourseStatuses);
+  }
+
 }

--- a/src/test/java/raisetech/student/management/service/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/student/management/service/converter/StudentConverterTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.data.StudentCourseStatus;
 import raisetech.student.management.domain.StudentDetail;
 
 class StudentConverterTest {
@@ -104,5 +105,53 @@ class StudentConverterTest {
         .anyMatch(studentCourse -> studentCourse.getId() == 3)).isFalse();
   }
 
+  @Test
+  void 申し込み状況に該当するものに限定して受講生詳細の変換でStudentCourseStatusに含まれるStudentCourseのみマッピングされること() {
+    // 事前準備
+    List<Student> students = new ArrayList<>(List.of(
+        new Student(1, "AAA", "aaa", null, "aaa@example.com", null, 1, null, null, false),
+        new Student(2, "BBB", "bbb", null, "bbb@example.com", null, 2, null, null, false)
+    ));
+    List<StudentCourse> studentCourses = new ArrayList<>(List.of(
+        new StudentCourse(1, 1, null, null, 1),
+        new StudentCourse(2, 1, null, null, 2),
+        new StudentCourse(3, 2, null, null, 1)
+    ));
+    List<StudentCourseStatus> studentCourseStatuses = new ArrayList<>(List.of(
+        new StudentCourseStatus(2, 2, "受講中")
+    ));
+    // 実行
+    List<StudentDetail> actual = sut.convertStudentDetailsWithStatus(students, studentCourses,
+        studentCourseStatuses);
+    // 検証
+    // actualのサイズが1であること
+    assertThat(actual.size()).isEqualTo(1);
+    // actualのStudentIdが1であること
+    assertThat(actual.get(0).getStudent().getId()).isEqualTo(1);
+    // actualのStudentCourseのサイズが1であること
+    assertThat(actual.get(0).getStudentCourses().size()).isEqualTo(1);
+    // actualのStudentCourseのIdが2であること
+    assertThat(actual.get(0).getStudentCourses().get(0).getId()).isEqualTo(2);
+  }
 
+  @Test
+  void 申し込み状況に該当するものに限定して受講生詳細の変換でStudentCourseStatusが空である場合はからのListが返されること() {
+    // 事前準備
+    List<Student> students = new ArrayList<>(List.of(
+        new Student(1, "AAA", "aaa", null, "aaa@example.com", null, 1, null, null, false),
+        new Student(2, "BBB", "bbb", null, "bbb@example.com", null, 2, null, null, false)
+    ));
+    List<StudentCourse> studentCourses = new ArrayList<>(List.of(
+        new StudentCourse(1, 1, null, null, 1),
+        new StudentCourse(2, 1, null, null, 2),
+        new StudentCourse(3, 2, null, null, 1)
+    ));
+    List<StudentCourseStatus> studentCourseStatuses = new ArrayList<>();
+    // 実行
+    List<StudentDetail> actual = sut.convertStudentDetailsWithStatus(students, studentCourses,
+        studentCourseStatuses);
+    // 検証
+    // actualが空であること
+    assertThat(actual.size()).isEqualTo(0);
+  }
 }


### PR DESCRIPTION
カリキュラム44の2段目として以下を実施しています。
1段目（受講生コース申し込み状況の導入）はすでにPR作成済みです。

## 概要
受講生コース申し込み状況の特定のstatusに紐づく受講生検索機能の追加

## コード変更内容
### Repository
- student_course_statusesから特定のstatusを持つものを抽出する@Selectメソッドを2つ追加

### Converter
- Students, StudentCourses, StudentCourseStatusesから、StudentCourseStatusesに含まれる要素のみを用いてStudentDetailsを返すメソッドの追加

### Service
- 受講中、仮申し込みそれぞれの受講生コース申し込み状況に対応するstudentDetailsを返すメソッドの追加

### Controller
- 上記のサービス2つを使用するAPIの追加

### その他
- 上記に関わるテストコードの追加